### PR TITLE
Correct license field in Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/posix4e/rust-metrics/"
 repository = "https://github.com/posix4e/rust-metrics/"
 readme = "README.md"
 keywords = ["metrics", "graphite", "ganglia", "opentsdb"]
-license = "Apache-2.0"
+license = "MIT/Apache-2.0"
 
 [dependencies]
 time = "0.1.35"


### PR DESCRIPTION
The README indicates that this crate is dual licensed under the
MIT and Apache 2 licenses, so update Cargo.toml to match.
