### PR TITLE
Resolve warnings

### DIFF
--- a/examples/web_server_with_carbon.rs
+++ b/examples/web_server_with_carbon.rs
@@ -31,7 +31,7 @@ fn main() {
         hc.max_value(100).precision(1);
         let mut h = Histogram::configured(hc).unwrap();
 
-        h.record(1, 1);
+        h.record(1, 1).unwrap();
 
         let mut r = StdRegistry::new();
         r.insert("meter1", m);

--- a/examples/web_server_with_carbon.rs
+++ b/examples/web_server_with_carbon.rs
@@ -11,7 +11,6 @@ use metrics::metrics::meter::*;
 use metrics::registry::{Registry, StdRegistry};
 use metrics::reporter::carbon::CarbonReporter;
 use std::sync::Arc;
-use std::collections::HashMap;
 use histogram::*;
 use std::thread;
 

--- a/examples/web_server_with_debug_port.rs
+++ b/examples/web_server_with_debug_port.rs
@@ -34,7 +34,7 @@ fn main() {
 
     let mut labels = HashMap::new();
     labels.insert(String::from("test"), String::from("test"));
-    let mut r = StdRegistry::new_with_labels(labels);
+    let r = StdRegistry::new_with_labels(labels);
     // r.insert("meter1", m);
     // r.insert("counter1", c);
     // r.insert("gauge1", g);

--- a/examples/web_server_with_debug_port.rs
+++ b/examples/web_server_with_debug_port.rs
@@ -8,7 +8,7 @@ use iron::status;
 use metrics::metrics::counter::*;
 use metrics::metrics::gauge::*;
 use metrics::metrics::meter::*;
-use metrics::registry::{Registry, StdRegistry};
+use metrics::registry::StdRegistry;
 use metrics::reporter::prometheus::PrometheusReporter;
 use std::sync::Arc;
 use std::collections::HashMap;

--- a/examples/web_server_with_debug_port.rs
+++ b/examples/web_server_with_debug_port.rs
@@ -30,7 +30,7 @@ fn main() {
     hc.max_value(100).precision(1);
     let mut h = Histogram::configured(hc).unwrap();
 
-    h.record(1, 1);
+    h.record(1, 1).unwrap();
 
     let mut labels = HashMap::new();
     labels.insert(String::from("test"), String::from("test"));

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -104,7 +104,7 @@ mod test {
         let mut c = HistogramConfig::new();
         c.max_value(100).precision(1);
         let mut h = Histogram::configured(c).unwrap();
-        h.record(1, 1);
+        h.record(1, 1).unwrap();
         r.insert("histogram", h);
     }
 }

--- a/src/reporter/base.rs
+++ b/src/reporter/base.rs
@@ -84,7 +84,7 @@ mod test {
         let mut hc = HistogramConfig::new();
         hc.max_value(100).precision(1);
         let mut h = Histogram::configured(hc).unwrap();
-        h.record(1, 1);
+        h.record(1, 1).unwrap();
 
         let mut r = StdRegistry::new();
         r.insert("meter1", m);

--- a/src/reporter/carbon.rs
+++ b/src/reporter/carbon.rs
@@ -278,7 +278,7 @@ mod test {
         hc.max_value(100).precision(1);
         let mut h = Histogram::configured(hc).unwrap();
 
-        h.record(1, 1);
+        h.record(1, 1).unwrap();
 
         let mut r = StdRegistry::new();
         r.insert("meter1", m);

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -3,7 +3,6 @@
 // We aren't collecting metrics properly we should be
 // on the regular collecting metrics, and snapshoting them
 // and sending them all up when prometheus comes to scrape.
-use metrics::metric::Metric;
 use registry::{Registry, StdRegistry};
 use std::thread;
 use std::sync::Arc;

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -140,13 +140,13 @@ fn to_pba(registry: Arc<Arc<StdRegistry<'static>>>) -> Vec<promo_proto::MetricFa
                 metric_family.set_field_type(promo_proto::MetricType::GAUGE);
 
             }
-            Meter(x) => {
+            Meter(_) => {
                 // TODO ask the prometheus guys what we want to do
                 pb_metric.set_summary(promo_proto::Summary::new());
                 metric_family.set_field_type(promo_proto::MetricType::SUMMARY);
 
             }
-            Histogram(x) => {
+            Histogram(_) => {
                 pb_metric.set_histogram(promo_proto::Histogram::new());
                 metric_family.set_field_type(promo_proto::MetricType::HISTOGRAM);
             }

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -187,7 +187,7 @@ mod test {
         hc.max_value(100).precision(1);
         let mut h = Histogram::configured(hc).unwrap();
 
-        h.record(1, 1);
+        h.record(1, 1).unwrap();
 
         let mut r = StdRegistry::new_with_labels(HashMap::new());
         r.insert("meter1", m);

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -26,6 +26,7 @@ use metrics::metric::MetricValue::{Counter, Gauge, Histogram, Meter};
 #[derive(Copy, Clone)]
 struct HandlerStorage;
 
+#[allow(dead_code)] // until `prefix is used
 pub struct PrometheusReporter {
     host_and_port: &'static str,
     // TODO to use as the application name?
@@ -44,6 +45,7 @@ impl Reporter for PrometheusReporter {
     }
 }
 
+#[allow(dead_code)] // until `prefix is used
 fn prefix(metric_line: String, prefix_str: &'static str) -> String {
     format!("{}.{}", prefix_str, metric_line)
 }

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -203,7 +203,7 @@ mod test {
         let client = hyper::client::Client::new();
         // Seems as though iron isn't running maybe
         thread::sleep(Duration::from_millis(1024));
-        let res = client.get("http://127.0.0.1:8080").send().unwrap();
+        client.get("http://127.0.0.1:8080").send().unwrap();
         // TODO fix url and check to make sure we got a valid protobuf
     }
 }


### PR DESCRIPTION
I personally find it better to resolve all warnings all the time because sometimes the compiler gives really awesome, helpful warnings, but they're hard to see if you always get a few warnings.

I see there are some TODO comments around where I've made some changes, but the changes I've made can always be undone as those get resolved!
