### PR TITLE
Casting cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ also provides reporting services. Current reporters include. Contact us on #rust
 fn make_a_bunch_of_metrics_store_them_and_start_sending_them_at_a_regular_interval_to_graphite_or_carbon() {
      let m = StdMeter::new();
      m.mark(100);
-    
+
      let mut c: StdCounter = StdCounter::new();
      c.inc();
-    
-     let mut g: StdGauge = StdGauge { value: 0f64 };
+
+     let mut g: StdGauge = StdGauge { value: 0.0 };
      g.set(1.2);
-    
+
      let mut hc = HistogramConfig::new();
      hc.max_value(100).precision(1);
      let mut h = Histogram::configured(hc).unwrap();
-    
+
      h.record(1, 1);
-    
+
      let mut r = StdRegistry::new();
      r.insert("meter1", m);
      r.insert("counter1", c);
      r.insert("gauge1", g);
      r.insert("histogram", h);
-    
+
      let arc_registry = Arc::new(r);
      CarbonReporter::new(arc_registry.clone(),
                          "test",

--- a/examples/web_server_with_carbon.rs
+++ b/examples/web_server_with_carbon.rs
@@ -25,7 +25,7 @@ fn main() {
         let mut c: StdCounter = StdCounter::new();
         c.inc();
 
-        let mut g: StdGauge = StdGauge { value: 0f64 };
+        let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
         let mut hc = HistogramConfig::new();

--- a/examples/web_server_with_debug_port.rs
+++ b/examples/web_server_with_debug_port.rs
@@ -23,7 +23,7 @@ fn main() {
     let mut c: StdCounter = StdCounter::new();
     c.inc();
 
-    let mut g: StdGauge = StdGauge { value: 0f64 };
+    let mut g: StdGauge = StdGauge { value: 0.0 };
     g.set(1.2);
 
     let mut hc = HistogramConfig::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(trivial_numeric_casts)]
+
 extern crate time;
 extern crate histogram;
 extern crate iron;

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -16,12 +16,12 @@ pub trait Counter {
 
 impl Counter for StdCounter {
     fn clear(&mut self) {
-        self.value = 0 as f64;
+        self.value = 0.0;
     }
 
     // inc(): Increment the counter by 1
     fn inc(&mut self) {
-        self.value = self.value + 1 as f64;
+        self.value = self.value + 1.0;
     }
 
     // inc(double v): Increment the counter by the given amount. MUST check that v >= 0.
@@ -43,7 +43,7 @@ impl Metric for StdCounter {
 
 impl StdCounter {
     pub fn new() -> StdCounter {
-        StdCounter { value: 0 as f64 }
+        StdCounter { value: 0.0 }
     }
 }
 
@@ -54,14 +54,14 @@ mod test {
     #[test]
     fn a_counting_counter() {
         let mut c: StdCounter = StdCounter::new();
-        c.add(1 as f64);
+        c.add(1.0);
 
-        assert!(c.value == 1 as f64);
+        assert!(c.value == 1.0);
 
         let mut c: StdCounter = StdCounter::new();
         c.inc();
 
-        assert!(c.value == 1 as f64);
+        assert!(c.value == 1.0);
     }
 
     #[test]
@@ -69,9 +69,9 @@ mod test {
         let c: StdCounter = StdCounter::new();
         let mut c_snapshot = c.snapshot();
 
-        c_snapshot.add(1 as f64);
+        c_snapshot.add(1.0);
 
-        assert!(c.value == 0 as f64);
-        assert!(c_snapshot.value == 1 as f64);
+        assert!(c.value == 0.0);
+        assert!(c_snapshot.value == 1.0);
     }
 }

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -27,7 +27,7 @@ impl Counter for StdCounter {
     // inc(double v): Increment the counter by the given amount. MUST check that v >= 0.
     // We crash with interger overflow
     fn add(&mut self, value: f64) {
-        self.value = self.value + value as f64;
+        self.value = self.value + value;
     }
 
     fn snapshot(self) -> StdCounter {

--- a/src/metrics/ewma.rs
+++ b/src/metrics/ewma.rs
@@ -81,7 +81,7 @@ mod test {
     // Returns whether the rate() is within 0.0001 of expected after ticking a minute
     fn within(e: &mut EWMA, expected: f64) -> bool {
         elapse_minute(e);
-        let r: f64 = e.rate();
+        let r = e.rate();
         (r - expected).abs() < 0.0001
     }
 
@@ -91,10 +91,8 @@ mod test {
         e.update(3);
         e.tick();
 
-        let r: f64;
-
         // initial
-        r = e.rate();
+        let r = e.rate();
         assert_eq!(r, 0.6);
 
         // 1 minute
@@ -149,7 +147,7 @@ mod test {
         e.update(3);
         e.tick();
 
-        let r: f64 = e.rate();
+        let r = e.rate();
         assert_eq!(r, 0.6);
 
         // 1 minute

--- a/src/metrics/ewma.rs
+++ b/src/metrics/ewma.rs
@@ -23,7 +23,7 @@ impl EWMA {
     pub fn rate(&self) -> f64 {
         let r = self.rate.lock().unwrap();
 
-        *r * (1e9 as f64)
+        *r * (1.0e9)
     }
 
     pub fn snapshot(&self) -> EWMASnapshot {
@@ -87,7 +87,7 @@ mod test {
 
     #[test]
     fn ewma1() {
-        let mut e = EWMA::new(1f64);
+        let mut e = EWMA::new(1.0);
         e.update(3);
         e.tick();
 

--- a/src/metrics/ewma.rs
+++ b/src/metrics/ewma.rs
@@ -55,15 +55,15 @@ impl EWMA {
         EWMA {
             uncounted: AtomicUsize::new(0),
             alpha: alpha,
-            rate: Mutex::new(0f64),
+            rate: Mutex::new(0.0),
             init: false,
         }
     }
 
     /// constructs a new EWMA for a n-minute moving average.
     pub fn new(rate: f64) -> EWMA {
-        let i: f64 = -5.0f64 / 60.0f64 / rate;
-        EWMA::new_by_alpha(1f64 - i.exp())
+        let i = -5.0 / 60.0 / rate;
+        EWMA::new_by_alpha(1.0 - i.exp())
     }
 }
 
@@ -95,162 +95,162 @@ mod test {
 
         // initial
         r = e.rate();
-        assert_eq!(r, 0.6f64);
+        assert_eq!(r, 0.6);
 
         // 1 minute
-        assert_eq!(within(&mut e, 0.22072766470286553f64), true);
+        assert_eq!(within(&mut e, 0.22072766470286553), true);
 
         // 2 minute
-        assert_eq!(within(&mut e, 0.08120116994196772f64), true);
+        assert_eq!(within(&mut e, 0.08120116994196772), true);
 
         // 3 minute
-        assert_eq!(within(&mut e, 0.029872241020718428f64), true);
+        assert_eq!(within(&mut e, 0.029872241020718428), true);
 
         // 4 minute
-        assert_eq!(within(&mut e, 0.01098938333324054f64), true);
+        assert_eq!(within(&mut e, 0.01098938333324054), true);
 
         // 5 minute
-        assert_eq!(within(&mut e, 0.004042768199451294f64), true);
+        assert_eq!(within(&mut e, 0.004042768199451294), true);
 
         // 6 minute
-        assert_eq!(within(&mut e, 0.0014872513059998212f64), true);
+        assert_eq!(within(&mut e, 0.0014872513059998212), true);
 
         // 7 minute
-        assert_eq!(within(&mut e, 0.0005471291793327122f64), true);
+        assert_eq!(within(&mut e, 0.0005471291793327122), true);
 
         // 8 minute
-        assert_eq!(within(&mut e, 0.00020127757674150815f64), true);
+        assert_eq!(within(&mut e, 0.00020127757674150815), true);
 
         // 9 minute
-        assert_eq!(within(&mut e, 7.404588245200814e-05f64), true);
+        assert_eq!(within(&mut e, 7.404588245200814e-05), true);
 
         // 10 minute
-        assert_eq!(within(&mut e, 2.7239957857491083e-05f64), true);
+        assert_eq!(within(&mut e, 2.7239957857491083e-05), true);
 
         // 11 minute
-        assert_eq!(within(&mut e, 1.0021020474147462e-05f64), true);
+        assert_eq!(within(&mut e, 1.0021020474147462e-05), true);
 
         // 12 minute
-        assert_eq!(within(&mut e, 3.6865274119969525e-06f64), true);
+        assert_eq!(within(&mut e, 3.6865274119969525e-06), true);
 
         // 13 minute
-        assert_eq!(within(&mut e, 1.3561976441886433e-06f64), true);
+        assert_eq!(within(&mut e, 1.3561976441886433e-06), true);
 
         // 14 minute
-        assert_eq!(within(&mut e, 4.989172314621449e-07f64), true);
+        assert_eq!(within(&mut e, 4.989172314621449e-07), true);
 
         // 15 minute
-        assert_eq!(within(&mut e, 1.8354139230109722e-07f64), true);
+        assert_eq!(within(&mut e, 1.8354139230109722e-07), true);
     }
 
     #[test]
     fn ewma5() {
-        let mut e = EWMA::new(5f64);
+        let mut e = EWMA::new(5.0);
         e.update(3);
         e.tick();
 
         let r: f64 = e.rate();
-        assert_eq!(r, 0.6f64);
+        assert_eq!(r, 0.6);
 
         // 1 minute
-        assert_eq!(within(&mut e, 0.49123845184678905f64), true);
+        assert_eq!(within(&mut e, 0.49123845184678905), true);
 
         // 2 minute
-        assert_eq!(within(&mut e, 0.4021920276213837f64), true);
+        assert_eq!(within(&mut e, 0.4021920276213837), true);
 
         // 3 minute
-        assert_eq!(within(&mut e, 0.32928698165641596f64), true);
+        assert_eq!(within(&mut e, 0.32928698165641596), true);
 
         // 4 minute
-        assert_eq!(within(&mut e, 0.269597378470333f64), true);
+        assert_eq!(within(&mut e, 0.269597378470333), true);
 
         // 5 minute
-        assert_eq!(within(&mut e, 0.2207276647028654f64), true);
+        assert_eq!(within(&mut e, 0.2207276647028654), true);
 
         // 6 minute
-        assert_eq!(within(&mut e, 0.18071652714732128f64), true);
+        assert_eq!(within(&mut e, 0.18071652714732128), true);
 
         // 7 minute
-        assert_eq!(within(&mut e, 0.14795817836496392f64), true);
+        assert_eq!(within(&mut e, 0.14795817836496392), true);
 
         // 8 minute
-        assert_eq!(within(&mut e, 0.12113791079679326f64), true);
+        assert_eq!(within(&mut e, 0.12113791079679326), true);
 
         // 9 minute
-        assert_eq!(within(&mut e, 0.09917933293295193f64), true);
+        assert_eq!(within(&mut e, 0.09917933293295193), true);
 
         // 10 minute
-        assert_eq!(within(&mut e, 0.08120116994196763f64), true);
+        assert_eq!(within(&mut e, 0.08120116994196763), true);
 
         // 11 minute
         assert_eq!(within(&mut e, 0.06648189501740036), true);
 
         // 12 minute
-        assert_eq!(within(&mut e, 0.05443077197364752f64), true);
+        assert_eq!(within(&mut e, 0.05443077197364752), true);
 
         // 13 minute
-        assert_eq!(within(&mut e, 0.04456414692860035f64), true);
+        assert_eq!(within(&mut e, 0.04456414692860035), true);
 
         // 14 minute
-        assert_eq!(within(&mut e, 0.03648603757513079f64), true);
+        assert_eq!(within(&mut e, 0.03648603757513079), true);
 
         // 15 minute
-        assert_eq!(within(&mut e, 0.0298722410207183831020718428f64), true);
+        assert_eq!(within(&mut e, 0.0298722410207183831020718428), true);
     }
 
     #[test]
     fn ewma15() {
-        let mut e = EWMA::new(15f64);
+        let mut e = EWMA::new(15.0);
         e.update(3);
         e.tick();
 
-        let r: f64 = e.rate();
-        assert_eq!(r, 0.6f64);
+        let r = e.rate();
+        assert_eq!(r, 0.6);
 
         // 1 minute
-        assert_eq!(within(&mut e, 0.5613041910189706f64), true);
+        assert_eq!(within(&mut e, 0.5613041910189706), true);
 
         // 2 minute
-        assert_eq!(within(&mut e, 0.5251039914257684f64), true);
+        assert_eq!(within(&mut e, 0.5251039914257684), true);
 
         // 3 minute
-        assert_eq!(within(&mut e, 0.4912384518467888184678905f64), true);
+        assert_eq!(within(&mut e, 0.4912384518467888184678905), true);
 
         // 4 minute
-        assert_eq!(within(&mut e, 0.459557003018789f64), true);
+        assert_eq!(within(&mut e, 0.459557003018789), true);
 
         // 5 minute
-        assert_eq!(within(&mut e, 0.4299187863442732f64), true);
+        assert_eq!(within(&mut e, 0.4299187863442732), true);
 
         // 6 minute
-        assert_eq!(within(&mut e, 0.4021920276213831f64), true);
+        assert_eq!(within(&mut e, 0.4021920276213831), true);
 
         // 7 minute
-        assert_eq!(within(&mut e, 0.37625345116383313f64), true);
+        assert_eq!(within(&mut e, 0.37625345116383313), true);
 
         // 8 minute
-        assert_eq!(within(&mut e, 0.3519877317060185f64), true);
+        assert_eq!(within(&mut e, 0.3519877317060185), true);
 
         // 9 minute
-        assert_eq!(within(&mut e, 0.3292869816564153165641596f64), true);
+        assert_eq!(within(&mut e, 0.3292869816564153165641596), true);
 
         // 10 minute
-        assert_eq!(within(&mut e, 0.3080502714195546f64), true);
+        assert_eq!(within(&mut e, 0.3080502714195546), true);
 
         // 11 minute
-        assert_eq!(within(&mut e, 0.2881831806538789f64), true);
+        assert_eq!(within(&mut e, 0.2881831806538789), true);
 
         // 12 minute
-        assert_eq!(within(&mut e, 0.26959737847033216f64), true);
+        assert_eq!(within(&mut e, 0.26959737847033216), true);
 
         // 13 minute
-        assert_eq!(within(&mut e, 0.2522102307052083f64), true);
+        assert_eq!(within(&mut e, 0.2522102307052083), true);
 
         // 14 minute
-        assert_eq!(within(&mut e, 0.23594443252115815f64), true);
+        assert_eq!(within(&mut e, 0.23594443252115815), true);
 
         // 15 minute
-        assert_eq!(within(&mut e, 0.2207276647028646247028654470286553f64),
+        assert_eq!(within(&mut e, 0.2207276647028646247028654470286553),
                    true);
     }
 }

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -74,8 +74,7 @@ impl Metric for StdGauge {
 fn timestamp() -> f64 {
     let timespec = get_time();
     // 1459440009.113178
-    let mills: f64 = timespec.sec as f64 + (timespec.nsec as f64 / 1000.0 / 1000.0 / 1000.0);
-    mills
+    timespec.sec as f64 + (timespec.nsec as f64 / 1000.0 / 1000.0 / 1000.0)
 }
 
 #[cfg(test)]

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -32,13 +32,13 @@ impl Gauge for StdGauge {
 
     // inc(): Increment the gauge by 1
     fn inc(&mut self) {
-        let value = self.value + 1 as f64;
+        let value = self.value + 1.0;
         self.value = value;
     }
 
     // dec(): Decrement the gauge by 1
     fn dec(&mut self) {
-        self.value = self.value - 1 as f64;
+        self.value = self.value - 1.0;
     }
 
     // implementing prometheus inc(double v): Increment the gauge by the given amount
@@ -84,12 +84,12 @@ mod test {
 
     #[test]
     fn create_and_snapshot() {
-        let g: StdGauge = StdGauge { value: 0f64 };
+        let g: StdGauge = StdGauge { value: 0.0 };
         let mut g_snapshot = g.snapshot();
 
-        g_snapshot.set(10f64);
+        g_snapshot.set(10.0);
 
-        assert_eq!(g.value, 0f64);
-        assert_eq!(g_snapshot.value, 10f64);
+        assert_eq!(g.value, 0.0);
+        assert_eq!(g_snapshot.value, 10.0);
     }
 }

--- a/src/metrics/meter.rs
+++ b/src/metrics/meter.rs
@@ -87,8 +87,7 @@ impl Meter for StdMeter {
         let s = self.data.lock().unwrap();
 
         if let Some(pos) = WINDOW.iter().position(|w| *w == rate) {
-            let r: f64 = s.rates[pos];
-            return r;
+            return s.rates[pos];
         }
         0.0
     }

--- a/src/metrics/meter.rs
+++ b/src/metrics/meter.rs
@@ -4,7 +4,7 @@ use std::sync::{Mutex, MutexGuard};
 use metrics::ewma::EWMA;
 use metrics::metric::{Metric, MetricValue};
 
-const WINDOW: [f64; 3] = [1f64, 5f64, 15f64];
+const WINDOW: [f64; 3] = [1.0, 5.0, 15.0];
 
 // A MeterSnapshot
 #[derive(Debug)]
@@ -90,7 +90,7 @@ impl Meter for StdMeter {
             let r: f64 = s.rates[pos];
             return r;
         }
-        0f64
+        0.0
     }
     /// Return the mean rate
     fn mean(&self) -> f64 {
@@ -126,12 +126,12 @@ impl StdMeter {
 
     pub fn new() -> StdMeter {
         let data: MeterSnapshot = MeterSnapshot {
-            count: 0i64,
-            rates: [0f64, 0f64, 0f64],
-            mean: 0f64,
+            count: 0,
+            rates: [0.0, 0.0, 0.0],
+            mean: 0.0,
         };
 
-        let ewma: [EWMA; 3] = [EWMA::new(1f64), EWMA::new(5f64), EWMA::new(15f64)];
+        let ewma: [EWMA; 3] = [EWMA::new(1.0), EWMA::new(5.0), EWMA::new(15.0)];
 
         StdMeter {
             data: Mutex::new(data),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -94,7 +94,7 @@ mod test {
     fn counter() {
         let mut r = StdRegistry::new();
         let mut c: StdCounter = StdCounter::new();
-        c.add(1 as f64);
+        c.add(1.0);
         r.insert("counter1", c);
     }
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -85,7 +85,7 @@ mod test {
     #[test]
     fn gauge() {
         let mut r = StdRegistry::new();
-        let mut g: StdGauge = StdGauge { value: 0f64 };
+        let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
         r.insert("gauge1", g);
     }

--- a/src/reporter/base.rs
+++ b/src/reporter/base.rs
@@ -96,7 +96,7 @@ mod test {
         let reporter = ConsoleReporter::new(arc_registry.clone(), "test");
         reporter.start(1);
         g.set(1.4);
-        thread::sleep(Duration::from_millis(200 as u64));
+        thread::sleep(Duration::from_millis(200));
         println!("poplopit");
 
     }

--- a/src/reporter/base.rs
+++ b/src/reporter/base.rs
@@ -78,7 +78,7 @@ mod test {
         let mut c: StdCounter = StdCounter::new();
         c.inc();
 
-        let mut g: StdGauge = StdGauge { value: 0f64 };
+        let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
         let mut hc = HistogramConfig::new();

--- a/src/reporter/carbon.rs
+++ b/src/reporter/carbon.rs
@@ -271,7 +271,7 @@ mod test {
         let mut c: StdCounter = StdCounter::new();
         c.inc();
 
-        let mut g: StdGauge = StdGauge { value: 0f64 };
+        let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
         let mut hc = HistogramConfig::new();

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -80,8 +80,7 @@ impl PrometheusReporter {
 fn timestamp() -> f64 {
     let timespec = time::get_time();
     // 1459440009.113178
-    let mills: f64 = timespec.sec as f64 + (timespec.nsec as f64 / 1000.0 / 1000.0 / 1000.0);
-    mills
+    timespec.sec as f64 + (timespec.nsec as f64 / 1000.0 / 1000.0 / 1000.0)
 }
 
 fn handler(req: &mut Request) -> IronResult<Response> {

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -202,7 +202,7 @@ mod test {
 
         let client = hyper::client::Client::new();
         // Seems as though iron isn't running maybe
-        thread::sleep(Duration::from_millis(1024 as u64));
+        thread::sleep(Duration::from_millis(1024));
         let res = client.get("http://127.0.0.1:8080").send().unwrap();
         // TODO fix url and check to make sure we got a valid protobuf
     }

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -180,7 +180,7 @@ mod test {
         let mut c: StdCounter = StdCounter::new();
         c.inc();
 
-        let mut g: StdGauge = StdGauge { value: 0f64 };
+        let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
         let mut hc = HistogramConfig::new();


### PR DESCRIPTION
This change cleans up some of the numerics handling-- there are places that the compiler can infer what type you want, so the suffixes and casting isn't needed. 

I also turned on a warning I really like that's off by default-- `trivial_numeric_casts`-- if you have something that's already an `f64` and you do `as f64` with it, you'll now get a warning that you don't need to do that :)
