### PR TITLE
Update Histogram to 0.6.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 time = "0.1.35"
-histogram =  "0.3.6"
+histogram =  "0.6.1"
 log = "0.3.6"
 iron = "0.3.0"
 router = "0.1."

--- a/examples/web_server_with_carbon.rs
+++ b/examples/web_server_with_carbon.rs
@@ -27,11 +27,13 @@ fn main() {
         let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
-        let mut hc = HistogramConfig::new();
-        hc.max_value(100).precision(1);
-        let mut h = Histogram::configured(hc).unwrap();
+        let mut h = Histogram::configure()
+                    .max_value(100)
+                    .precision(1)
+                    .build()
+                    .unwrap();
 
-        h.record(1, 1).unwrap();
+        h.increment_by(1, 1).unwrap();
 
         let mut r = StdRegistry::new();
         r.insert("meter1", m);

--- a/examples/web_server_with_debug_port.rs
+++ b/examples/web_server_with_debug_port.rs
@@ -26,11 +26,13 @@ fn main() {
     let mut g: StdGauge = StdGauge { value: 0.0 };
     g.set(1.2);
 
-    let mut hc = HistogramConfig::new();
-    hc.max_value(100).precision(1);
-    let mut h = Histogram::configured(hc).unwrap();
+    let mut h = Histogram::configure()
+                .max_value(100)
+                .precision(1)
+                .build()
+                .unwrap();
 
-    h.record(1, 1).unwrap();
+    h.increment_by(1, 1).unwrap();
 
     let mut labels = HashMap::new();
     labels.insert(String::from("test"), String::from("test"));

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -102,10 +102,12 @@ mod test {
     #[test]
     fn histogram() {
         let mut r = StdRegistry::new();
-        let mut c = HistogramConfig::new();
-        c.max_value(100).precision(1);
-        let mut h = Histogram::configured(c).unwrap();
-        h.record(1, 1).unwrap();
+        let mut h = Histogram::configure()
+            .max_value(100)
+            .precision(1)
+            .build()
+            .unwrap();
+        h.increment_by(1, 1).unwrap();
         r.insert("histogram", h);
     }
 }

--- a/src/reporter/base.rs
+++ b/src/reporter/base.rs
@@ -81,10 +81,13 @@ mod test {
         let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
-        let mut hc = HistogramConfig::new();
-        hc.max_value(100).precision(1);
-        let mut h = Histogram::configured(hc).unwrap();
-        h.record(1, 1).unwrap();
+        let mut h = Histogram::configure()
+            .max_value(100)
+            .precision(1)
+            .build()
+            .unwrap();
+
+        h.increment_by(1, 1).unwrap();
 
         let mut r = StdRegistry::new();
         r.insert("meter1", m);

--- a/src/reporter/carbon.rs
+++ b/src/reporter/carbon.rs
@@ -140,7 +140,7 @@ fn send_histogram_metric(metric_name: &str,
                          prefix_str: &'static str,
                          ts: Timespec)
                          -> Result<String, Error> {
-    let count = histogram.count();
+    let count = histogram.into_iter().count();
     // let sum = histogram.sum();
     // let mean = sum / count;
     let max = histogram.percentile(100.0).unwrap();
@@ -274,11 +274,13 @@ mod test {
         let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
-        let mut hc = HistogramConfig::new();
-        hc.max_value(100).precision(1);
-        let mut h = Histogram::configured(hc).unwrap();
+        let mut h = Histogram::configure()
+            .max_value(100)
+            .precision(1)
+            .build()
+            .unwrap();
 
-        h.record(1, 1).unwrap();
+        h.increment_by(1, 1).unwrap();
 
         let mut r = StdRegistry::new();
         r.insert("meter1", m);

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -183,11 +183,13 @@ mod test {
         let mut g: StdGauge = StdGauge { value: 0.0 };
         g.set(1.2);
 
-        let mut hc = HistogramConfig::new();
-        hc.max_value(100).precision(1);
-        let mut h = Histogram::configured(hc).unwrap();
+        let mut h = Histogram::configure()
+            .max_value(100)
+            .precision(1)
+            .build()
+            .unwrap();
 
-        h.record(1, 1).unwrap();
+        h.increment_by(1, 1).unwrap();
 
         let mut r = StdRegistry::new_with_labels(HashMap::new());
         r.insert("meter1", m);


### PR DESCRIPTION
- Updating the Histogram dependency from 0.3.x to 0.6.x
- Change call-sites to be compatible with new Histogram API
