### PR TITLE
Wrap metrics in a Metric enum. Remove MetricValue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ fn make_a_bunch_of_metrics_store_them_and_start_sending_them_at_a_regular_interv
      let mut c = StdCounter::new();
      c.inc();
 
-     let mut g = StdGauge::default();
+     let mut g = StdGauge::new();
      g.set(1.2);
 
      let mut hc = HistogramConfig::new();
@@ -30,10 +30,10 @@ fn make_a_bunch_of_metrics_store_them_and_start_sending_them_at_a_regular_interv
      h.record(1, 1);
 
      let mut r = StdRegistry::new();
-     r.insert("meter1", m);
-     r.insert("counter1", c);
-     r.insert("gauge1", g);
-     r.insert("histogram", h);
+     r.insert("meter1", Metric::Meter(Box::new(m)));
+     r.insert("counter1", Metric::Counter(c.clone()));
+     r.insert("gauge1", Metric::Gauge(g.clone()));
+     r.insert("histogram", Metric::Histogram(h));
 
      let arc_registry = Arc::new(r);
      CarbonReporter::new(arc_registry.clone(),

--- a/examples/web_server_with_carbon.rs
+++ b/examples/web_server_with_carbon.rs
@@ -11,7 +11,7 @@ extern crate histogram;
 
 use iron::prelude::*;
 use iron::status;
-use metrics::metrics::{Counter, Gauge, Meter, StdCounter, StdGauge, StdMeter};
+use metrics::metrics::{Counter, Gauge, Meter, Metric, StdCounter, StdGauge, StdMeter};
 use metrics::registry::{Registry, StdRegistry};
 use metrics::reporter::CarbonReporter;
 use std::sync::Arc;
@@ -25,10 +25,10 @@ fn main() {
         let m = StdMeter::new();
         m.mark(100);
 
-        let mut c = StdCounter::new();
+        let c = StdCounter::new();
         c.inc();
 
-        let mut g = StdGauge::default();
+        let g = StdGauge::new();
         g.set(1.2);
 
         let mut h = Histogram::configure()
@@ -40,10 +40,10 @@ fn main() {
         h.increment_by(1, 1).unwrap();
 
         let mut r = StdRegistry::new();
-        r.insert("meter1", m);
-        r.insert("counter1", c);
-        r.insert("gauge1", g);
-        r.insert("histogram", h);
+        r.insert("meter1", Metric::Meter(Box::new(m)));
+        r.insert("counter1", Metric::Counter(c.clone()));
+        r.insert("gauge1", Metric::Gauge(g.clone()));
+        r.insert("histogram", Metric::Histogram(h));
 
         let arc_registry = Arc::new(r);
         let reporter = CarbonReporter::new(arc_registry.clone(),

--- a/examples/web_server_with_debug_port.rs
+++ b/examples/web_server_with_debug_port.rs
@@ -11,8 +11,8 @@ extern crate histogram;
 
 use iron::prelude::*;
 use iron::status;
-use metrics::metrics::{Counter, Gauge, Meter, StdCounter, StdGauge, StdMeter};
-use metrics::registry::StdRegistry;
+use metrics::metrics::{Counter, Gauge, Meter, Metric, StdCounter, StdGauge, StdMeter};
+use metrics::registry::{Registry, StdRegistry};
 use metrics::reporter::PrometheusReporter;
 use std::sync::Arc;
 use std::collections::HashMap;
@@ -24,10 +24,10 @@ fn main() {
     let m = StdMeter::new();
     m.mark(100);
 
-    let mut c = StdCounter::new();
+    let c = StdCounter::new();
     c.inc();
 
-    let mut g = StdGauge::default();
+    let g = StdGauge::new();
     g.set(1.2);
 
     let mut h = Histogram::configure()
@@ -40,11 +40,11 @@ fn main() {
 
     let mut labels = HashMap::new();
     labels.insert(String::from("test"), String::from("test"));
-    let r = StdRegistry::new_with_labels(labels);
-    // r.insert("meter1", m);
-    // r.insert("counter1", c);
-    // r.insert("gauge1", g);
-    // r.insert("histogram", h);
+    let mut r = StdRegistry::new_with_labels(labels);
+    r.insert("meter1", Metric::Meter(Box::new(m)));
+    r.insert("counter1", Metric::Counter(c.clone()));
+    r.insert("gauge1", Metric::Gauge(g.clone()));
+    r.insert("histogram", Metric::Histogram(h));
 
     let arc_registry = Arc::new(r);
     let reporter =

--- a/src/metrics/meter.rs
+++ b/src/metrics/meter.rs
@@ -6,7 +6,6 @@
 
 #![allow(missing_docs)]
 
-use metrics::{Metric, MetricValue};
 use std::sync::{Mutex, MutexGuard};
 use time::{get_time, Timespec};
 use utils::EWMA;
@@ -30,7 +29,7 @@ pub struct StdMeter {
 }
 
 // A Meter trait
-pub trait Meter: Metric {
+pub trait Meter {
     fn snapshot(&self) -> MeterSnapshot;
 
     fn mark(&self, n: i64);
@@ -97,12 +96,6 @@ impl Meter for StdMeter {
         let s = self.data.lock().unwrap();
 
         s.count
-    }
-}
-
-impl Metric for StdMeter {
-    fn export_metric(&self) -> MetricValue {
-        MetricValue::Meter(self.snapshot())
     }
 }
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -6,6 +6,8 @@
 
 //! Metrics
 
+use std::sync::Arc;
+
 mod counter;
 mod gauge;
 mod meter;
@@ -17,23 +19,15 @@ pub use self::meter::{Meter, MeterSnapshot, StdMeter};
 /// a Metric
 use histogram::Histogram;
 
-//  TODO rename to MetricSnapshot
 #[allow(missing_docs)]
-pub trait Metric: Send + Sync {
-    fn export_metric(&self) -> MetricValue;
-}
-
-#[allow(missing_docs)]
-impl Metric for Histogram {
-    fn export_metric(&self) -> MetricValue {
-        MetricValue::Histogram(self.clone())
-    }
-}
-
-#[allow(missing_docs)]
-pub enum MetricValue {
-    Counter(CounterSnapshot),
-    Gauge(GaugeSnapshot),
-    Meter(MeterSnapshot),
+pub enum Metric {
+    Counter(Arc<Counter>),
+    Gauge(Arc<Gauge>),
+    Meter(Box<Meter>),
     Histogram(Histogram),
 }
+
+#[allow(unsafe_code)]
+unsafe impl Send for Metric {}
+#[allow(unsafe_code)]
+unsafe impl Sync for Metric {}


### PR DESCRIPTION
`Meter` still needs to be fixed to be an `Arc` and to use `RefCell`, but this is getting there and fixes a number of things.
