### PR TITLE
Meter must be Send+Sync.

### DIFF
--- a/src/metrics/meter.rs
+++ b/src/metrics/meter.rs
@@ -36,7 +36,7 @@ pub struct StdMeter {
 }
 
 // A Meter trait
-pub trait Meter {
+pub trait Meter: Send + Sync {
     fn snapshot(&self) -> MeterSnapshot;
 
     fn mark(&self, n: i64);


### PR DESCRIPTION
This is preparation for making metrics Send+Sync and getting rid
of a unsafe impl.
