### PR TITLE
Fix unresolved PrometheusReporter

### DIFF
--- a/examples/web_server_with_debug_port.rs
+++ b/examples/web_server_with_debug_port.rs
@@ -18,9 +18,9 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use histogram::Histogram;
 
-#[cfg(not(prometheus))]
+#[cfg(not(feature = "prometheus"))]
 fn main () { }
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 fn main() {
     use metrics::reporter::PrometheusReporter;
         println!("WebServer Starting");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,14 +28,14 @@ pub mod registry;
 pub mod reporter;
 pub mod utils;
 
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 extern crate iron;
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 extern crate router;
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 extern crate persistent;
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 extern crate protobuf; // depend on rust-protobuf runtime
 #[allow(unsafe_code)]
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 mod promo_proto; // add generated crate

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -10,12 +10,12 @@
 
 mod carbon;
 mod console;
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 mod prometheus;
 
 pub use self::carbon::CarbonReporter;
 pub use self::console::ConsoleReporter;
-#[cfg(prometheus)]
+#[cfg(feature = "prometheus")]
 pub use self::prometheus::PrometheusReporter;
 
 pub trait Reporter: Send + Sync {


### PR DESCRIPTION
Hello @posix4e 

I was trying to build a prometheus demo in rust. Cargo report an error, even after I enable the feature `prometheus`, 

```
unresolved import `metrics::reporter::PrometheusReporter`.
```

This PR should fix this problem.
#44

Thank you for the great project!
