### PR TITLE
Remove from reporter

### DIFF
--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -26,6 +26,12 @@ use std::collections::HashMap;
 // Todo create sync wrappers with mutexes.
 // Currently our only reporter runs as a seperate thread so stop returns its handler
 // In future versions we wont be so specific
+
+enum ReporterMsg {
+    AddMetric(String, Metric, Option<HashMap<String, String>>),
+    RemoveMetric(String),
+}
+
 pub trait Reporter: Send {
     fn get_unique_reporter_name(&self) -> &str;
     fn stop(self) -> Result<JoinHandle<Result<(), String>>, String>;
@@ -35,6 +41,9 @@ pub trait Reporter: Send {
                              metric: Metric,
                              labels: Option<HashMap<String, String>>)
                              -> Result<(), String>;
+    // This will be added once it is implemented for prometheus
+    // fn remove <S: Into<String>>(&mut self, name: S) -> Result<(), String>;
+
     fn add<S: Into<String>>(&mut self, name: S, metric: Metric) -> Result<(), String> {
         self.addl(name, metric, None)
     }

--- a/src/reporter/prometheus.rs
+++ b/src/reporter/prometheus.rs
@@ -202,10 +202,10 @@ mod test {
         g.set(2);
 
         let mut h = Histogram::configure()
-            .max_value(100)
-            .precision(1)
-            .build()
-            .unwrap();
+                        .max_value(100)
+                        .precision(1)
+                        .build()
+                        .unwrap();
 
         h.increment_by(1, 1).unwrap();
 


### PR DESCRIPTION
This adds a new method on the console and carbon reporters
that can be used to remove a metric from their records.

This will be used in the following cases:
 - Metrics on dynamic objects
 - Control of metrics so that you can turn on and off metrics programatically.

The end goal is to have this as a method on Reporter, but I thought I would
get feedback on carbon and console before implementing the more tricky prometheus
metrics.

I've not refactored much as I'm not so sure of the desired end state. 

Looking at the prometheus code it looks like it is going to be interesting to  implement 
removal as the metrics are stored in an Lrucache with a timestamp as the key. I would have to store
that id with a metric (and have a sender send it back) or change the id to be a  
hash of the name rather than a time stamp? That seems like the best plan to me.