### PR TITLE
Add remove to prometheus reporter

### DIFF
--- a/prometheus_reporter/Cargo.toml
+++ b/prometheus_reporter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus_reporter"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Alex Newman <posix4e@gmail.com>"]
 description = "Prometheus support for rust"
 

--- a/prometheus_reporter/src/lib.rs
+++ b/prometheus_reporter/src/lib.rs
@@ -26,6 +26,8 @@ use lru_cache::LruCache;
 use protobuf::Message;
 use std::sync::{Arc, RwLock};
 use std::thread;
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
 
 // http handler storage
 #[derive(Copy, Clone)]
@@ -37,14 +39,11 @@ const CONTENT_TYPE: &'static str = "application/vnd.google.protobuf; \
                                     encoding=delimited";
 
 impl Key for HandlerStorage {
-    type Value = Arc<RwLock<LruCache<i64, promo_proto::MetricFamily>>>;
+    type Value = Arc<RwLock<LruCache<u64, promo_proto::MetricFamily>>>;
 }
 
-fn get_seconds() -> i64 {
-    time::now().to_timespec().sec
-}
 
-fn families_to_u8(metric_families: Vec<(&i64, &promo_proto::MetricFamily)>) -> Vec<u8> {
+fn families_to_u8(metric_families: Vec<(&u64, &promo_proto::MetricFamily)>) -> Vec<u8> {
     let mut buf = Vec::new();
     for (_, family) in metric_families {
         family.write_length_delimited_to_writer(&mut buf).unwrap();
@@ -67,7 +66,7 @@ fn handler(req: &mut Request) -> IronResult<Response> {
 
 // TODO perhaps we autodiscover the host and port
 pub struct PrometheusReporter {
-    cache: Arc<RwLock<LruCache<i64, promo_proto::MetricFamily>>>
+    cache: Arc<RwLock<LruCache<u64, promo_proto::MetricFamily>>>
 }
 
 impl PrometheusReporter {
@@ -92,17 +91,38 @@ impl PrometheusReporter {
     }
     // TODO require start before add
     pub fn add(&mut self, metric_families: Vec<promo_proto::MetricFamily>) -> Result<i64, String> {
-        let ts = get_seconds();
+        
         match self.cache.write() {
             Ok(mut cache) => {
                 let mut counter = 0;
                 for metric_family in metric_families {
-                    cache.insert(ts, metric_family);
+
+                    let mut hasher = DefaultHasher::new();
+                    metric_family.get_name().hash(&mut hasher);
+                    cache.insert(hasher.finish(), metric_family);
                     counter = counter + 1;
                 }
                 Ok(counter)
             }
             Err(y) => Err(format!("Unable to add {}", y)),
+        }
+    }
+
+    pub fn remove(&mut self, metrics_to_remove: Vec<String>) -> Result<i64, String> {
+        let mut hasher = DefaultHasher::new();
+        match self.cache.write() {
+            Ok(mut cache) => {
+                let mut counter = 0;
+                for metric_name_to_remove in metrics_to_remove {
+
+                    let mut hasher = DefaultHasher::new();
+                    metric_name_to_remove.hash(&mut hasher);
+                    cache.remove(&hasher.finish());
+                    counter = counter + 1;
+                }
+                Ok(counter)
+            }
+            Err(y) => Err(format!("Unable to remove {}", y)),
         }
     }
 }


### PR DESCRIPTION
This is the first step of adding remove to prometheus reporter. We need to release a new version of this and then I'll bump the version referenced by the core metrics (or we could switch to lazily referencing the crate via path, it depends how much refactoring you expect).

I've got the code ready to use it, once this is merged. 

As suggested before I switched over to using a hash for the LRUCache. 

