### PR TITLE
Fix issues with reporting to the console

### DIFF
--- a/src/reporter/console.rs
+++ b/src/reporter/console.rs
@@ -23,10 +23,7 @@ impl Reporter for ConsoleReporter {
     }
     fn stop(self) -> Result<thread::JoinHandle<Result<(), String>>, String> {
         match self.metrics.send(Err("stop")) {
-            Ok(_) => {
-                println!("stopped");
-                Ok(self.join_handle)
-            },
+            Ok(_) => Ok(self.join_handle),
             Err(x) => Err(format!("Unable to stop reporter: {}", x)),
         }
     }


### PR DESCRIPTION
This appears to fix #84. The issue was that &rx only gets the metrics once when they're added to the reporter... it never logs them after that; this PR will forward back to &rx (in a loop) so they're continually logged on interval.

I'm not sure if this is the best way to fix this, but it does indeed fix it.